### PR TITLE
Update image switch to use Ubuntu2204

### DIFF
--- a/create-high-availability-vm-with-sets.sh
+++ b/create-high-availability-vm-with-sets.sh
@@ -62,7 +62,7 @@ for i in `seq 1 2`; do
         --resource-group $RgName \
         --name webVM$i \
         --nics webNic$i \
-        --image UbuntuLTS \
+        --image Ubuntu2204 \
         --availability-set portalAvailabilitySet \
         --generate-ssh-keys \
         --custom-data cloud-init.txt

--- a/create-high-availability-vm-with-zones.sh
+++ b/create-high-availability-vm-with-zones.sh
@@ -119,7 +119,7 @@ for i in `seq 1 2`; do
     --resource-group $RgName \
     --name dbVM$i \
     --nics dbNic$i \
-    --image UbuntuLTS \
+    --image Ubuntu2204 \
     --zone $i \
     --generate-ssh-keys \
     --custom-data backend-init.txt


### PR DESCRIPTION
Updated the shell script after seeing the below warning via Azure CLI.

`Consider using the "Ubuntu2204" alias. On April 30, 2023,the image deployed by the "UbuntuLTS" alias reaches its end of life. The "UbuntuLTS" will be removed with the breaking change release of Fall 2023.`