### PR TITLE
Update create-high-availability-vm-with-sets.sh

### DIFF
--- a/create-high-availability-vm-with-sets.sh
+++ b/create-high-availability-vm-with-sets.sh
@@ -62,7 +62,7 @@ for i in `seq 1 2`; do
         --resource-group $RgName \
         --name webVM$i \
         --nics webNic$i \
-        --image UbuntuLTS \
+        --image Ubuntu2204 \
         --availability-set portalAvailabilitySet \
         --generate-ssh-keys \
         --custom-data cloud-init.txt


### PR DESCRIPTION
Got an error when trying to deploy. UbuntuLTS image probably no longer exsist. changed to Ubuntu2204: 

Invalid image "UbuntuLTS". Use a valid image URN, custom image name, custom image id, VHD blob URI, or pick an image from ['CentOS85Gen2', 'Debian11', 'FlatcarLinuxFreeGen2', 'OpenSuseLeap154Gen2', 'RHELRaw8LVMGen2', 'SuseSles15SP3', 'Ubuntu2204', 'Win2022Datacenter', 'Win2022AzureEditionCore', 'Win2019Datacenter', 'Win2016Datacenter', 'Win2012R2Datacenter', 'Win2012Datacenter', 'Win2008R2SP1']. See vm create -h for more information on specifying an image.