### PR TITLE
Update create-high-availability-vm-with-sets.sh

### DIFF
--- a/create-high-availability-vm-with-sets.sh
+++ b/create-high-availability-vm-with-sets.sh
@@ -62,7 +62,7 @@ for i in `seq 1 2`; do
         --resource-group $RgName \
         --name webVM$i \
         --nics webNic$i \
-        --image UbuntuLTS \
+        --image Ubuntu2204 \
         --availability-set portalAvailabilitySet \
         --generate-ssh-keys \
         --custom-data cloud-init.txt


### PR DESCRIPTION
updated image to Ubuntu2204 hence "UbuntuLTS" became deprecated 